### PR TITLE
Adding more reasons to deprecate 7050

### DIFF
--- a/draft-buraglio-deprecate7050.md
+++ b/draft-buraglio-deprecate7050.md
@@ -42,6 +42,7 @@ informative:
   RFC4861:
   RFC4862:
   RFC6105:
+  RFC6146:
   RFC6145:
   RFC6147:
   RFC6877:

--- a/draft-buraglio-deprecate7050.md
+++ b/draft-buraglio-deprecate7050.md
@@ -36,12 +36,15 @@ author:
     organization: Google
     email: "furry13@gmail.com"
 normative:
+  RFC7050:
 
 informative:
+  RFC4861:
+  RFC4862:
   RFC6105:
   RFC6145:
+  RFC6147:
   RFC6877:
-  RFC7050:
   RFC8781:
   RFC8880:
   RFC9463:
@@ -56,18 +59,23 @@ RFC7050 describes a method for detecting the presence of DNS64 and for learning 
 
 # Introduction
 
-[RFC8781] describes a Neighbor Discovery option to be used in Router Advertisements (RAs) to communicate prefixes of Network Address and Protocol Translation from IPv6 clients to IPv4 servers (NAT64) to hosts. This approach has the advantage of using the same communication channel IPv6 clients use to discover other network configurations such as the network's default route. This means network administrators can secure this configuration along with other configurations IPv6 requires using a single approach such as RA Guard [RFC6105].
+The DNS-based mechanism defined in [RFC7050] was the very first mechanism available for nodes to discover the PREF64 information.
+However since the publication of RFC7050 other methods have been developed, to address some of [RFC7050] limitations. 
+
+For example, [RFC8781] describes a Neighbor Discovery option to be used in Router Advertisements (RAs) to communicate prefixes of Network Address and Protocol Translation from IPv6 clients to IPv4 servers (NAT64) to hosts. This approach has the advantage of using the same communication channel IPv6 clients use to discover other network configurations such as the network's default route. This means network administrators can secure this configuration along with other configurations IPv6 requires using a single approach such as RA Guard [RFC6105].
+
+Taking into account some fundamental flaws of [RFC7050] mechanism, it seems desirable to deprecate it and recommend new deployments and implementations to use better methods to obtain PREF64 information.
 
 
 # Conventions and Definitions
 
-NAT64
+NAT64: a mechanism for translating IPv6 packets to IPv4 packets and vice versa.  The translation is done by translating the packet headers according to the IP/ICMP Translation Algorithm defined in [RFC6145].
 
-DNS64
+DNS64: a mechanism for synthesizing AAAA records from A records, defined in [RFC6147].
 
-Router Advertisement
+Router Advertisement: A packet used by Neighbor Discovery [RFC4861] and StateLess Address AutoConfiguration (SLAAC, [RFC4862]) to advertize the presence of the routers, togther with other IPv6 configuration information.
 
-pref64
+pref64(or NAT64 prefix): An IPv6 prefix used for IPv6 address synthesis and for network addresses and protocols translation from IPv6 clients to IPv4 servers, [RFC6146].
 
 {::boilerplate bcp14-tagged}
 

--- a/draft-buraglio-deprecate7050.md
+++ b/draft-buraglio-deprecate7050.md
@@ -42,6 +42,7 @@ informative:
   RFC6145:
   RFC7050:
   RFC8781:
+  RFC8880:
   RFC9463:
   RFC9499:
 
@@ -71,17 +72,23 @@ pref64
 
 # Existing issues with RFC 7050
 
-In addition to creating a wider attack surface for IPv6 deployments, [RFC7050] has additional challenges worth noting to justify declaring it legacy.
+DNS-based method of discovering the NAT64 prefix introduces some challenges, which make this approach less preferable than most recently developed alternatives (such as PREF64 RA option, [RFC8781]).
+This section outlines the key issues, associated with [RFC7050].
 
-## Definition of secure channel {secure-channel-def}
+## Security Implications
+
+As discussed in Section 7 of [RFC7050], the DNS-based PREF64 discovery is prone to DNS spoofing attack.
+In addition to creating a wider attack surface for IPv6 deployments, [RFC7050] has other security challenges worth noting to justify declaring it legacy.
+
+### Definition of secure channel {#secure-channel-def}
 
 [RFC7050] requires a node's communication channel with a DNS64 server to be a "secure channel" which it defines to mean "a communication channel a node has between itself and a DNS64 server protecting DNS protocol-related messages from interception and tampering." This need is redundant when another communication mechanism of IPv6-related configuration, specific Router Advertisements, can already be defended against tampering by RA Guard [RFC6105]. Requiring nodes to implement two defense mechanisms when only one is necessary when [RFC8781] is used in place of [RFC7050] creates unnecessary risk.
 
-## Secure channel example of IPsec
+### Secure channel example of IPsec
 
 One of the two examples [RFC7050] defines to qualify a communication channel with a DNS64 server is the use of an "IPsec-based virtual private network (VPN) tunnel". As of the time of this writing, this is not supported as a practice by any common operating system DNS client. While they could, there have also since been multiple mechanisms defined for performing DNS-specific encryption such as those defined in [RFC9499] that would be more appropriately scoped to the applicable DNS traffic. These are also compatible with encrypted DNS advertisement by the network using Discovery of Network-designated Resolvers [RFC9463] that would ensure the clients know in advance that the DNS64 server supported the encryption mechanism.
 
-## Secure channel example of link layer encryption
+### Secure channel example of link layer encryption
 
 The other example given by [RFC7050] that would allow a communication channel with a DNS64 server to qualify as a "secure channel" is the use of a "link layer utilizing data encryption technologies". As of the time of this writing, most common link layer implementations use data encryption already with no extra effort needed on the part of network nodes. While this appears to be a trivial way to satisfy this requirement, it also renders the requirement meaningless since any node along the path can still read the higher-layer DNS traffic containing the translation prefix. This seems to be at odds with the definition of "secure channel" as explained in {{Section 2.2 of RFC7050}}.
 

--- a/draft-buraglio-deprecate7050.md
+++ b/draft-buraglio-deprecate7050.md
@@ -61,7 +61,7 @@ RFC7050 describes a method for detecting the presence of DNS64 and for learning 
 # Introduction
 
 The DNS-based mechanism defined in [RFC7050] was the very first mechanism available for nodes to discover the PREF64 information.
-However since the publication of RFC7050 other methods have been developed, to address some of [RFC7050] limitations. 
+However since the publication of RFC7050 other methods have been developed, to address some of [RFC7050] limitations.
 
 For example, [RFC8781] describes a Neighbor Discovery option to be used in Router Advertisements (RAs) to communicate prefixes of Network Address and Protocol Translation from IPv6 clients to IPv4 servers (NAT64) to hosts. This approach has the advantage of using the same communication channel IPv6 clients use to discover other network configurations such as the network's default route. This means network administrators can secure this configuration along with other configurations IPv6 requires using a single approach such as RA Guard [RFC6105].
 
@@ -104,7 +104,7 @@ Therefore until the process described in Section 3 of [RFC7050] is completed, th
 ## Inflexibility
 
 Section 3 of [RFC7050] requires that the node SHALL cache the replies received during the PREF64 discovery and SHOULD repeat the discovery process ten seconds before the TTL of the Well-Known Name's synthetic AAAA resource record expires.
-As a result, once the PREF64 is discovered, it will be used until the TTL expired, or until the node disconnects from the network. 
+As a result, once the PREF64 is discovered, it will be used until the TTL expired, or until the node disconnects from the network.
 There is no mechanims for an operator to force the PREF64 rediscovery on the node without disconnecting the node from the network.
 If the operator needs to change the PREF64 value used in the network, they need to proactively reduce the TTL value returned by the DNS64 server.
 This method has two significant drawbacks:

--- a/draft-buraglio-deprecate7050.md
+++ b/draft-buraglio-deprecate7050.md
@@ -1,6 +1,6 @@
 ---
-title: "Deprication of DNS64 for Discovery of IPv6 Prefix Used for IPv6 Address Synthesis"
-abbrev: "Deprication of DNS64 for Discovery of IPv6 Prefix Used for IPv6 Address Synthesis"
+title: "Deprecation of DNS64 for Discovery of IPv6 Prefix Used for IPv6 Address Synthesis"
+abbrev: "Deprecate RFC7050"
 category: info
 
 docname: draft-buraglio-deprecate7050-latest
@@ -9,8 +9,8 @@ number:
 date:
 consensus: true
 v: 3
-# area: AREA
-# workgroup: WG Working Group
+area: ops
+workgroup: dnsop
 keyword:
  - IPv6
  - DNS64
@@ -31,6 +31,10 @@ author:
     fullname: Tommy Jensen
     organization: Microsoft
     email: "tojens.ietf@gmail.com"
+ -
+    fullname: Jen Linkova
+    organization: Google
+    email: "furry13@gmail.com"
 normative:
 
 informative:
@@ -43,7 +47,7 @@ informative:
 
 --- abstract
 
-[RFC7050] describes a method for detecting the presence of DNS64 and for learning the IPv6 prefix used for protocol translation ([RFC6145]). This methodology depends on the existence of a well-known IPv4-only fully qualified domain name "ipv4only.arpa.". Because newer methods exist that lack the requirement of a higher level protocol, instead using existing operations in the form of native router advertisements, discovery of the IPv6 prefix used for protocol translation using [RFC7050] is deprecated to legacy status.
+RFC7050 describes a method for detecting the presence of DNS64 and for learning the IPv6 prefix used for protocol translation (RFC6145). This methodology depends on the existence of a well-known IPv4-only fully qualified domain name "ipv4only.arpa.". Because newer methods exist that lack the requirement of a higher level protocol, instead using existing operations in the form of native router advertisements, discovery of the IPv6 prefix used for protocol translation using RFC7050 is deprecated to legacy status.
 
 --- middle
 


### PR DESCRIPTION
- Additional reasons to deprecate:
- using 3rd-party resolevrs
- updating the PREF64 info
- delays

Also adding more text into the INtro, removing the citation in the Abstract and adding myself as a co-author